### PR TITLE
If you refresh home and look at the network panel you will see cors e…

### DIFF
--- a/content-discovery-service/src/routes.ts
+++ b/content-discovery-service/src/routes.ts
@@ -12,6 +12,7 @@ const corsMiddleware: express.Handler = (req, res, next) => {
     const origin = req.get('origin');
     if (allowedCorsDomains.includes(origin)) {
         res.header("Access-Control-Allow-Origin", origin);
+        res.header("Access-Control-Allow-Credentials", "true");
     }
     next();
 };


### PR DESCRIPTION
…rrors

This is because Home is sending include credentials in the fetch request but the demo is not adding that in the response headers (so it is saying it doesn't accept them). The data still shows up in the list but a bunch of errors are raised. This should resolve that.