### PR TITLE
Updated dos to reflect changes in rvm 6.4.1.1

### DIFF
--- a/how-to/add-an-application-to-workspace/public/dos.json
+++ b/how-to/add-an-application-to-workspace/public/dos.json
@@ -1,6 +1,6 @@
 {
   "desktopSettings": {
-    "openfinSystemApplications": {
+    "systemApps": {
       "home": {
         "customConfig": {
           "appDirectoryUrl": "http://localhost:8080/apps.json",


### PR DESCRIPTION
RVM Update 6.4.1.1 Changed the dos name from openfinSystemApplications to systemApps and the change needed to be reflected here. Please note if you are using a version prior to release 6.4.1.1 then you can rename the setting back until you upgrade.

More details here: https://developer.openfin.co/versions/?product=RVM&version=6.4.1.1