### PR TITLE
WRK-279 Fix: Workspace Starter expects openfin-cli to be installed globally

### DIFF
--- a/how-to/add-an-application-to-workspace/package.json
+++ b/how-to/add-an-application-to-workspace/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node ./build/index.js",
     "dos": "desktop-owner-settings.bat && (npm run -s kill:fin || true) && (npm run -s kill:rvm || true)",
-    "start:workspace": "openfin -l -c https://home.openfin.co/app.json",
+    "start:workspace": "PATH=$(npm bin):$PATH openfin -l -c https://home.openfin.co/app.json",
     "kill:fin": "cmd.exe /c taskkill /F /IM OpenFin.exe /T",
     "kill:rvm": "cmd.exe /c taskkill /F /IM OpenFinRVM.exe /T"
   },

--- a/how-to/add-an-application-to-workspace/package.json
+++ b/how-to/add-an-application-to-workspace/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node ./build/index.js",
     "dos": "desktop-owner-settings.bat && (npm run -s kill:fin || true) && (npm run -s kill:rvm || true)",
-    "start:workspace": "PATH=$(npm bin):$PATH openfin -l -c https://home.openfin.co/app.json",
+    "start:workspace": "npx openfin -l -c https://home.openfin.co/app.json",
     "kill:fin": "cmd.exe /c taskkill /F /IM OpenFin.exe /T",
     "kill:rvm": "cmd.exe /c taskkill /F /IM OpenFinRVM.exe /T"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "workspace-starter",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-starter",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### Changelog
Make workspace-starter work without needing openfin-cli to be originally installed globally. 

There were multiple ways to do this
1. Using `npm bin`
2. Using `npx`

Option 2 was shorter and cleaner so opted to that.

#### Jira Issue(s)

- WRK-279

#### Checklist

I have created and/or updated any relevant…

- [ ] README.md and/or inline documentation
- [ ] storybook stories
- [ ] tests

