### PR TITLE
Adding an example of launching manifests and native apps

### DIFF
--- a/how-to/add-an-application-to-workspace/README.md
+++ b/how-to/add-an-application-to-workspace/README.md
@@ -41,7 +41,7 @@ $ start npm run start
 5. Start Workspace.
 
 ```bash
-$ npm run start:workspace
+$ npm run workspace
 ```
 
 6. Navigate to the `Launch` or `Workspaces` view in the Home UI.
@@ -62,5 +62,11 @@ In this example, the [Desktop Owner Settings file](public/dos.json) has its `app
 previously mentioned [list of applications](public/apps.json) and its `workspacesUrl` configured to the
 [list of workspaces](public/workspaces.json). Hence, all of the content that Home renders is sourced from OpenFin's
 Content Discovery Service.
+
+The Content Discovery Service contains an example of entries that:
+
+* Load views into OpenFin Browser
+* Launch an OpenFin Application using it's manifest file
+* Launch a native application
 
 ### Read more about [working with Workspace](https://developers.openfin.co/of-docs/docs/workspace-overview). 

--- a/how-to/add-an-application-to-workspace/package.json
+++ b/how-to/add-an-application-to-workspace/package.json
@@ -7,15 +7,14 @@
     "build": "tsc",
     "start": "node ./build/index.js",
     "dos": "desktop-owner-settings.bat && (npm run -s kill:fin || true) && (npm run -s kill:rvm || true)",
-    "start:workspace": "openfin -l -c https://home.openfin.co/app.json",
+    "workspace": "start fins://system-apps/workspace",
     "kill:fin": "cmd.exe /c taskkill /F /IM OpenFin.exe /T",
-    "kill:rvm": "cmd.exe /c taskkill /F /IM OpenFinRVM.exe /T"
+    "kill:rvm": "cmd.exe /c taskkill /F /IM OpenFinRVM.exe /T"   
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "openfin-cli": "^3.0.2"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/how-to/add-an-application-to-workspace/public/apps.json
+++ b/how-to/add-an-application-to-workspace/public/apps.json
@@ -31,5 +31,42 @@
         "icon": "https://openfin-iex.experolabs.com/favicon.ico"
       }
     ]
+  },
+  {
+    "appId": "notifications-generator",
+    "name": "notifications-studio",
+    "title": "Notifications Studio",
+    "manifestType": "manifest",
+    "version": null,
+    "intents": [],
+    "publisher": "openfin",
+    "description": "Notifications Studio: Test sending Notifications",
+    "manifest": "https://cdn.openfin.co/studio/notification/app.json",
+    "contactEmail": "contact@company.com",
+    "customConfig": [],
+    "supportEmail": "support@company.com",
+    "icons": [
+      {
+        "icon": "https://cdn.openfin.co/demos/notifications/generator/images/icon-blue.png"
+      }
+    ],
+    "tags": [],
+    "images": [],
+    "internal": false,
+    "enableLayout": false,
+    "suppressReporting": false,
+    "isCertified": true,
+    "suppressRuntimeAnalytics": false,
+    "enableDosCapture": false,
+    "active": true
+  },
+  {
+    "appId": "Notepad",
+    "title": "Notepad",
+    "manifestType": "external",
+    "publisher": "openfin",
+    "manifest": "notepad.exe",
+    "icons": [
+     ]
   }
 ]


### PR DESCRIPTION
This should help developers quickly experiment with their own openfin manifests and native apps. It also drops the fins requirement as it was only used to launch a manifest and we can launch workspace using a fins link and system-apps.