### PR TITLE
Update dos.json to use workspace instead of home and drop home urls 

### DIFF
--- a/how-to/add-an-application-to-workspace/public/dos.json
+++ b/how-to/add-an-application-to-workspace/public/dos.json
@@ -1,7 +1,7 @@
 {
   "desktopSettings": {
     "systemApps": {
-      "home": {
+      "workspace": {
         "customConfig": {
           "appDirectoryUrl": "http://localhost:8080/apps.json",
           "workspacesUrl": "http://localhost:8080/workspaces.json",

--- a/how-to/add-an-application-to-workspace/src/routes.ts
+++ b/how-to/add-an-application-to-workspace/src/routes.ts
@@ -7,7 +7,7 @@ export default router;
  * In order for Home to make the cross origin request to our server,
  * we must allow CORS on Home's domains.
  */
-const allowedCorsDomains = ["https://home-staging.openfin.co", "https://home.openfin.co", "https://cdn.openfin.co"];
+const allowedCorsDomains = ["https://cdn.openfin.co"];
 const corsMiddleware: express.Handler = (req, res, next) => {
     const origin = req.get('origin');
     if (allowedCorsDomains.includes(origin)) {


### PR DESCRIPTION
Update DOS.json to use workspace instead of home as workspace is the new key.

Remove home and home staging from the cors list as we have moved to the cdn.